### PR TITLE
name change csvParsers to csvDateFormat

### DIFF
--- a/hssqlppp/src/Database/HsSqlPpp/Internals/AstInternal.ag
+++ b/hssqlppp/src/Database/HsSqlPpp/Internals/AstInternal.ag
@@ -1465,7 +1465,7 @@ data CsvOptions = NewCsvOptions
   , csvErrorOptions :: Maybe ErrorOptions
   , csvLimit :: Maybe Integer
   , csvOffset :: Maybe Integer
-  , csvParsers :: Maybe String
+  , csvDateFormat :: Maybe String
   }
   deriving (Show,Eq,Typeable,Data)
 

--- a/hssqlppp/src/Database/HsSqlPpp/Pretty.lhs
+++ b/hssqlppp/src/Database/HsSqlPpp/Pretty.lhs
@@ -4,7 +4,7 @@
 >
 >    Some effort is made produce human readable output.
 > -}
-> {-# LANGUAGE PatternGuards,OverloadedStrings,TypeSynonymInstances,FlexibleInstances, LambdaCase #-}
+> {-# LANGUAGE RecordWildCards,PatternGuards,OverloadedStrings,TypeSynonymInstances,FlexibleInstances, LambdaCase #-}
 > module Database.HsSqlPpp.Pretty
 >     (--convert a sql ast to text
 >      printStatements
@@ -1139,26 +1139,16 @@ syntax maybe should error instead of silently breaking
 >     text "path" <+> quotes (text path) <+> ppCsvOpts csvOpts
 
 > ppCsvOpts :: CsvOptions -> Doc
-> ppCsvOpts NewCsvOptions
->   { csvFilePath = path
->   , csvFieldDelimiter = delimiter
->   , csvRecordDelimiter = record
->   , csvTextQualifier = textQualifier
->   , csvNullMarker = nullMarker
->   , csvErrorOptions = errorOpts
->   , csvLimit = limit
->   , csvOffset = offset
->   , csvParsers = parsers
->   } =
+> ppCsvOpts NewCsvOptions{..} =
 >   let
->     ppDelimiter = maybe empty ppDel delimiter
->     ppRecord = maybe empty ppRec record
->     ppTextQualifier = maybe empty ppTxtQual textQualifier
->     ppNullMarker = maybe empty ppNullMark nullMarker
->     ppErrorOptions = maybe empty ppErrOpts errorOpts
->     ppLimit = maybe empty ppLim limit
->     ppOffset = maybe empty ppOff offset
->     ppParsers = maybe empty ppParse parsers
+>     ppDelimiter = maybe empty ppDel csvFieldDelimiter
+>     ppRecord = maybe empty ppRec csvRecordDelimiter
+>     ppTextQualifier = maybe empty ppTxtQual csvTextQualifier
+>     ppNullMarker = maybe empty ppNullMark csvNullMarker
+>     ppErrorOptions = maybe empty ppErrOpts csvErrorOptions
+>     ppLimit = maybe empty ppLim csvLimit
+>     ppOffset = maybe empty ppOff csvOffset
+>     ppDateFormat = maybe empty ppDateForm csvDateFormat
 >   in
 >     ppDelimiter
 >       <+> ppRecord
@@ -1167,7 +1157,7 @@ syntax maybe should error instead of silently breaking
 >       <+> ppErrorOptions
 >       <+> ppLimit
 >       <+> ppOffset
->       <+> ppParsers
+>       <+> ppDateFormat
 
 > ppDel :: Delimiter -> Doc
 > ppDel del = 
@@ -1211,8 +1201,8 @@ syntax maybe should error instead of silently breaking
 > ppOff :: Integer -> Doc
 > ppOff num = text "offset" <+> text (show num)
 
-> ppParse :: String -> Doc
-> ppParse p = text "parsers" <+> quotes (text p)
+> ppDateForm :: String -> Doc
+> ppDateForm p = text "date format" <+> quotes (text p)
 
 > -- plpgsql
 >

--- a/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/CreateTable.lhs
+++ b/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/CreateTable.lhs
@@ -374,7 +374,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >       ]
 >       ,Stmt "create or replace external table test (fielda text,fieldb int) using format parquet with path 'filepath' ;"
@@ -400,7 +400,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >       ]
 >
@@ -419,7 +419,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >      ]
 >      ,Stmt "create or replace external table test (fielda text,fieldb int) using format csv with path 'filepath' record delimiter '\n\r' ;"
@@ -437,7 +437,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >      ]
 >      ,Stmt "create or replace external table test (fielda text,fieldb int) using format csv with path 'filepath' field delimiter '|' record delimiter '\n\r';"
@@ -455,7 +455,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >      ]
 >      ,Stmt "create or replace external table test (fielda text,fieldb int) using format csv with path 'filepath' record delimiter '\n\r' field delimiter '|';"
@@ -473,7 +473,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' record delimiter '\n\r' field delimiter E'\\111';"
@@ -491,7 +491,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' null marker 'null';"
@@ -509,7 +509,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' null marker 'null' text qualifier '|';"
@@ -527,7 +527,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' null marker 'null' text qualifier E'\\111';"
@@ -545,7 +545,7 @@ quick sanity check
 >           , csvErrorOptions = Nothing
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error abort;"
@@ -563,7 +563,7 @@ quick sanity check
 >           , csvErrorOptions = Just EOAbort
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50;"
@@ -581,7 +581,7 @@ quick sanity check
 >           , csvErrorOptions = Just (EOSkipRowLimit 50 NoReportSkippedRows)
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]  
 >     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50 report skipped rows;"
@@ -599,10 +599,10 @@ quick sanity check
 >           , csvErrorOptions = Just (EOSkipRowLimit 50 ReportSkippedRows)
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
->           , csvParsers = Nothing
+>           , csvDateFormat = Nothing
 >           }
 >     ]
->     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50 limit 40 offset 1 parsers 'b=oracle';"
+>     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50 limit 40 offset 1 date format 'ISO8601C';"
 >     [CreateExternalTable ea (name "test")
 >         [ att "fielda" "text"
 >         , att "fieldb" "int"
@@ -617,7 +617,7 @@ quick sanity check
 >           , csvErrorOptions = Just (EOSkipRowLimit 50 NoReportSkippedRows)
 >           , csvLimit = Just 40
 >           , csvOffset = Just 1
->           , csvParsers = Just "b=oracle"
+>           , csvDateFormat = Just "ISO8601C"
 >           }
 >     ]
 >    ]

--- a/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/Dml.lhs
+++ b/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/Dml.lhs
@@ -141,13 +141,13 @@ copy, bit crap at the moment
 >            ]
 >          )
 >        ]
->      , s "copy tbl (a,b) from 'filename' with delimiter '|' parsers 'b=oracle';"
+>      , s "copy tbl (a,b) from 'filename' with delimiter '|' parsers 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filename" )
 >          ( OldCopyFromOptions
 >            [ CopyFromDelimiter "|"
->            , CopyFromParsers "b=oracle"
+>            , CopyFromParsers "ISO8601"
 >            ]
 >          )
 >        ]
@@ -172,7 +172,7 @@ copy, bit crap at the moment
 >            ]
 >          )
 >        ]
->      , s "copy tbl (a,b) from 'filename' with delimiter '|' error_log 'errors.log' error_verbosity 1 parsers 'b=oracle';"
+>      , s "copy tbl (a,b) from 'filename' with delimiter '|' error_log 'errors.log' error_verbosity 1 parsers 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filename" )
@@ -180,7 +180,7 @@ copy, bit crap at the moment
 >            [ CopyFromDelimiter "|"
 >            , CopyFromErrorLog "errors.log"
 >            , CopyFromErrorVerbosity 1
->            , CopyFromParsers "b=oracle"
+>            , CopyFromParsers "ISO8601"
 >            ]
 >          )
 >        ]
@@ -193,7 +193,7 @@ copy, bit crap at the moment
 >            ]
 >          )
 >        ]
->      , s "copy tbl (a,b) from 'filename' with delimiter E'\\111' error_log 'errors.log' error_verbosity 1 parsers 'b=oracle';"
+>      , s "copy tbl (a,b) from 'filename' with delimiter E'\\111' error_log 'errors.log' error_verbosity 1 parsers 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filename" )
@@ -201,11 +201,11 @@ copy, bit crap at the moment
 >            [ CopyFromOctalDelimiter 73
 >            , CopyFromErrorLog "errors.log"
 >            , CopyFromErrorVerbosity 1
->            , CopyFromParsers "b=oracle"
+>            , CopyFromParsers "ISO8601"
 >            ]
 >          )
 >        ]
->      , s "copy tbl (a,b) from 'filename' with error_log 'errors.log' error_verbosity 1 delimiter E'\\111' parsers 'b=oracle';"
+>      , s "copy tbl (a,b) from 'filename' with error_log 'errors.log' error_verbosity 1 delimiter E'\\111' parsers 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filename" )
@@ -213,14 +213,14 @@ copy, bit crap at the moment
 >            [ CopyFromOctalDelimiter 73
 >            , CopyFromErrorLog "errors.log"
 >            , CopyFromErrorVerbosity 1
->            , CopyFromParsers "b=oracle"
+>            , CopyFromParsers "ISO8601"
 >            ]
 >          )
 >        ]
 
 -- new copy from options
 
->      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error abort offset 1 limit 10 parsers 'b=oracle';"
+>      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error abort offset 1 limit 10 date format 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filepath" )
@@ -233,11 +233,11 @@ copy, bit crap at the moment
 >            , csvErrorOptions = Just EOAbort
 >            , csvLimit = Just 10
 >            , csvOffset = Just 1
->            , csvParsers = Just "b=oracle"
+>            , csvDateFormat = Just "ISO8601"
 >            }
 >          )
 >        ]
->      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error skip row 100 offset 1 limit 10 parsers 'b=oracle';"
+>      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error skip row 100 offset 1 limit 10 date format 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filepath" )
@@ -250,7 +250,7 @@ copy, bit crap at the moment
 >            , csvErrorOptions = Just (EOSkipRowLimit 100 NoReportSkippedRows)
 >            , csvLimit = Just 10
 >            , csvOffset = Just 1
->            , csvParsers = Just "b=oracle"
+>            , csvDateFormat = Just "ISO8601"
 >            }
 >          )
 >        ]


### PR DESCRIPTION
1. Name change csvParsers to csvDateFormat:
AstInternal
ParserInternal
Pretty
Tests

behaviour change: csv date format will now apply to all date columns globaly.
e.g: instaed of "b=ISO8206" -> "ISO8206"

2. Fixed warnings at parser internal function body