### PR TITLE
syntax change for error options - new csv options

### DIFF
--- a/hssqlppp/src/Database/HsSqlPpp/Ast.lhs
+++ b/hssqlppp/src/Database/HsSqlPpp/Ast.lhs
@@ -128,6 +128,7 @@
 >     ,Delimiter(..)
 >     ,ErrorOptions(..)
 >     ,ReportSkippedRows(..)
+>     ,RowMax(..)
 >     ) where
 >
 > import Database.HsSqlPpp.Internals.AstInternal

--- a/hssqlppp/src/Database/HsSqlPpp/Internals/AstInternal.ag
+++ b/hssqlppp/src/Database/HsSqlPpp/Internals/AstInternal.ag
@@ -153,6 +153,7 @@ module {Database.HsSqlPpp.Internals.AstInternal}
    ,Delimiter(..)
    ,ErrorOptions(..)
    ,ReportSkippedRows(..)
+   ,RowMax(..)
 }
 
 {
@@ -1483,11 +1484,17 @@ data Delimiter
 
 data ErrorOptions
   = EOAbort
-  | EOSkipRowLimit Integer ReportSkippedRows
+  | EOSkipRow RowMax ReportSkippedRows
   deriving (Show,Eq,Typeable,Data)
 
 data ReportSkippedRows
   = NoReportSkippedRows
   | ReportSkippedRows
   deriving (Show,Eq,Typeable,Data)
+
+data RowMax
+  = NoRowMax
+  | RowMaxNum Integer
+  deriving (Show,Eq,Typeable,Data)
 }
+ 

--- a/hssqlppp/src/Database/HsSqlPpp/Parsing/ParserInternal.lhs
+++ b/hssqlppp/src/Database/HsSqlPpp/Parsing/ParserInternal.lhs
@@ -966,11 +966,16 @@ ddl
 >        abort = keyword "abort" $> EOAbort
 >        skip = do
 >          mapM_ keyword ["skip","row"]
->          num <- (integer <?> "positive integer")
+>          let
+>            rowLimitNum = do
+>              keyword "max"
+>              num <- (integer <?> "positive integer")
+>              pure $ RowMaxNum num
+>          rowLimit <- rowLimitNum <|> pure NoRowMax
 >          report <-
 >            (mapM_ keyword ["report","skipped","rows"] $> ReportSkippedRows)
 >            <|> pure NoReportSkippedRows
->          pure $ EOSkipRowLimit num report
+>          pure $ EOSkipRow rowLimit report
 >      in do
 >        mapM_ keyword ["on","error"]
 >        skip <|> abort

--- a/hssqlppp/src/Database/HsSqlPpp/Pretty.lhs
+++ b/hssqlppp/src/Database/HsSqlPpp/Pretty.lhs
@@ -1183,10 +1183,15 @@ syntax maybe should error instead of silently breaking
 >   text "on error" <+> case eo of
 >   EOAbort ->
 >     text "abort"
->   EOSkipRowLimit num isReport ->
+>   EOSkipRow limit isReport ->
 >     text "skip"
 >       <+> text "row"
->       <+> text (show num)
+>       <+> case limit of
+>         RowMaxNum num ->
+>           text "max"
+>             <+> text (show num)
+>         NoRowMax ->
+>           empty
 >       <+> case isReport of
 >         ReportSkippedRows ->
 >           text "report"

--- a/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/CreateTable.lhs
+++ b/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/CreateTable.lhs
@@ -566,7 +566,7 @@ quick sanity check
 >           , csvDateFormat = Nothing
 >           }
 >     ]
->     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50;"
+>     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row max 50;"
 >     [CreateExternalTable ea (name "test")
 >         [ att "fielda" "text"
 >         , att "fieldb" "int"
@@ -578,13 +578,13 @@ quick sanity check
 >           , csvRecordDelimiter = Nothing
 >           , csvTextQualifier = Nothing
 >           , csvNullMarker = Nothing
->           , csvErrorOptions = Just (EOSkipRowLimit 50 NoReportSkippedRows)
+>           , csvErrorOptions = Just (EOSkipRow (RowMaxNum 50) NoReportSkippedRows)
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
 >           , csvDateFormat = Nothing
 >           }
 >     ]  
->     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50 report skipped rows;"
+>     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row max 50 report skipped rows;"
 >     [CreateExternalTable ea (name "test")
 >         [ att "fielda" "text"
 >         , att "fieldb" "int"
@@ -596,13 +596,13 @@ quick sanity check
 >           , csvRecordDelimiter = Nothing
 >           , csvTextQualifier = Nothing
 >           , csvNullMarker = Nothing
->           , csvErrorOptions = Just (EOSkipRowLimit 50 ReportSkippedRows)
+>           , csvErrorOptions = Just (EOSkipRow (RowMaxNum 50) ReportSkippedRows)
 >           , csvLimit = Nothing
 >           , csvOffset = Nothing
 >           , csvDateFormat = Nothing
 >           }
 >     ]
->     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row 50 limit 40 offset 1 date format 'ISO8601C';"
+>     ,Stmt "create or replace external table test (fielda text, fieldb int) using format csv with path 'filepath' on error skip row max 50 limit 40 offset 1 date format 'ISO8601C';"
 >     [CreateExternalTable ea (name "test")
 >         [ att "fielda" "text"
 >         , att "fieldb" "int"
@@ -614,7 +614,7 @@ quick sanity check
 >           , csvRecordDelimiter = Nothing
 >           , csvTextQualifier = Nothing
 >           , csvNullMarker = Nothing
->           , csvErrorOptions = Just (EOSkipRowLimit 50 NoReportSkippedRows)
+>           , csvErrorOptions = Just (EOSkipRow (RowMaxNum 50) NoReportSkippedRows)
 >           , csvLimit = Just 40
 >           , csvOffset = Just 1
 >           , csvDateFormat = Just "ISO8601C"

--- a/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/Dml.lhs
+++ b/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/Dml.lhs
@@ -237,7 +237,7 @@ copy, bit crap at the moment
 >            }
 >          )
 >        ]
->      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error skip row 100 offset 1 limit 10 date format 'ISO8601';"
+>      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error skip row max 100 offset 1 limit 10 date format 'ISO8601';"
 >        [ CopyFrom ea (name "tbl")
 >          [ Nmc "a", Nmc "b" ]
 >          ( CopyFilename "filepath" )
@@ -247,7 +247,24 @@ copy, bit crap at the moment
 >            , csvRecordDelimiter = Nothing
 >            , csvTextQualifier = Just (StringDelimiter "?")
 >            , csvNullMarker = Just "null"
->            , csvErrorOptions = Just (EOSkipRowLimit 100 NoReportSkippedRows)
+>            , csvErrorOptions = Just (EOSkipRow (RowMaxNum 100) NoReportSkippedRows)
+>            , csvLimit = Just 10
+>            , csvOffset = Just 1
+>            , csvDateFormat = Just "ISO8601"
+>            }
+>          )
+>        ]
+>      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error skip row offset 1 limit 10 date format 'ISO8601';"
+>        [ CopyFrom ea (name "tbl")
+>          [ Nmc "a", Nmc "b" ]
+>          ( CopyFilename "filepath" )
+>          ( NewCopyFromOptions $ NewCsvOptions
+>            { csvFilePath = "filepath"
+>            , csvFieldDelimiter = Just (StringDelimiter "|")
+>            , csvRecordDelimiter = Nothing
+>            , csvTextQualifier = Just (StringDelimiter "?")
+>            , csvNullMarker = Just "null"
+>            , csvErrorOptions = Just (EOSkipRow NoRowMax NoReportSkippedRows)
 >            , csvLimit = Just 10
 >            , csvOffset = Just 1
 >            , csvDateFormat = Just "ISO8601"


### PR DESCRIPTION
Due to logical error: 
Duplicity for using the word "limit" once for limiting the number of rows to be read and also for "skip row limit" it has been decided by the p.o with r&d approval to change the syntax to"skip row max"