### PR TITLE
Removed new copy from syntax to fix dialect issue

### DIFF
--- a/hssqlppp/src/Database/HsSqlPpp/Parsing/ParserInternal.lhs
+++ b/hssqlppp/src/Database/HsSqlPpp/Parsing/ParserInternal.lhs
@@ -600,15 +600,13 @@ other dml-type stuff
 >     from p tableName cols = do
 >        keyword "from"
 >        src <- extrStr <$> stringLit
->        let
->          newCopyFromOptions =
->            fmap NewCopyFromOptions $ optionsCsv $ pure src
 
->        opts <-
->          choice
->            [ lookAhead (stmtEnd $ not reqSemi) $> OldCopyFromOptions []
->            , keyword "with" *> ((keyword "options" *> newCopyFromOptions) <|> oldCopyFromOptions)
->            ]
+         let
+           newCopyFromOptions =
+             fmap NewCopyFromOptions $ optionsCsv $ pure src
+
+>        opts <- option (OldCopyFromOptions []) $ do
+>          keyword "with" *> oldCopyFromOptions
 >        return $ CopyFrom p tableName cols (CopyFilename src) opts
 >     to p src = do
 >        keyword "to"

--- a/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/Dml.lhs
+++ b/hssqlppp/tests/Database/HsSqlPpp/Tests/Parsing/Dml.lhs
@@ -218,6 +218,9 @@ copy, bit crap at the moment
 >          )
 >        ]
 
+
+> {-
+
 -- new copy from options
 
 >      , s "copy tbl (a,b) from 'filepath' with options field delimiter '|' text qualifier '?' null marker 'null' on error abort offset 1 limit 10 date format 'ISO8601';"
@@ -271,6 +274,9 @@ copy, bit crap at the moment
 >            }
 >          )
 >        ]
+> -}
+
+
 >      , s "copy tbl to 'file';"
 >        [ CopyTo ea (CopyTable (name "tbl") []) "file" []]
 >      ,s "copy tbl(a,b) to 'file';"


### PR DESCRIPTION
Adding the new copy from csv syntax caused an issue that related to sql server dialect.

This pull request reverts the changes and comments out the new tests.